### PR TITLE
Fix for recent versions of eslint

### DIFF
--- a/dist/rules/sort-requires.js
+++ b/dist/rules/sort-requires.js
@@ -28,7 +28,7 @@ module.exports = {
           loc: { start: group[0].loc.start, end: last(group).loc.end },
           message: 'This group of requires is not sorted',
           fix: function fix(fixer) {
-            return fixer.replaceTextRange([group[0].start, last(group).end], texts.join('\n'));
+            return fixer.replaceTextRange([group[0].range[0], last(group).range[1]], texts.join('\n'));
           }
         });
       }

--- a/lib/rules/sort-requires.js
+++ b/lib/rules/sort-requires.js
@@ -26,7 +26,7 @@ module.exports = {
           loc: { start: group[0].loc.start, end: last(group).loc.end },
           message: 'This group of requires is not sorted',
           fix: fixer => fixer.replaceTextRange(
-            [group[0].start, last(group).end],
+            [group[0].range[0], last(group).range[1]],
             texts.join('\n')
           ),
         });


### PR DESCRIPTION
I'm not entirely sure what happend, but after running npm install on my project, eslint suddenly started complaining with these messages:

```
ESLint: 7.32.0

AssertionError [ERR_ASSERTION]: Fix has invalid range: {
  "range": [
    null,
    null
  ],
  "text": "const checkRequiredFiles = require(\"react-dev-utils/checkRequiredFiles\");\nconst configFactory = require(\"../config/webpack.config\");\nconst FileSizeReporter = require(\"react-dev-utils/FileSizeReporter\");\nconst formatWebpackMessages = require(\"react-dev-utils/formatWebpackMessages\");\nconst fs
 = require(\"fs-extra\");\nconst path = require(\"path\");\nconst paths = require(\"../config/paths\");\nconst printBuildError = require(\"react-dev-utils/printBuildError\");\nconst printHostingInstructions = require(\"react-dev-utils/printHostingInstructions\");\nconst webpack = require(\"webpack\");"
}
    at assertValidFix (D:\WebstormProjects\Valetudo_Github\node_modules\eslint\lib\linter\report-translator.js:125:9)
    at normalizeFixes (D:\WebstormProjects\Valetudo_Github\node_modules\eslint\lib\linter\report-translator.js:200:5)
    at D:\WebstormProjects\Valetudo_Github\node_modules\eslint\lib\linter\report-translator.js:364:49
    at Object.report (D:\WebstormProjects\Valetudo_Github\node_modules\eslint\lib\linter\linter.js:926:41)
    at check (D:\WebstormProjects\Valetudo_Github\node_modules\eslint-plugin-sort-requires\dist\rules\sort-requires.js:27:17)
    at Array.forEach (<anonymous>)
    at ProgramExit (D:\WebstormProjects\Valetudo_Github\node_modules\eslint-plugin-sort-requires\dist\rules\sort-requires.js:69:16)
    at D:\WebstormProjects\Valetudo_Github\node_modules\eslint\lib\linter\safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (D:\WebstormProjects\Valetudo_Github\node_modules\eslint\lib\linter\safe-emitter.js:45:38)
```

This PR is just the fix found here (https://github.com/quisquous/cactbot/pull/3755) applied to this project.
I suspect that create-react-app might have a `^` in its package.json for the eslint dependency but honestly I have no idea.

I just need things to work again. You might want to double-check this.
Especially in regards to compatibility with older eslint versions if you care about backwards compatibility.